### PR TITLE
start delete function

### DIFF
--- a/src/main/java/com/example/final_task/controller/SwimmersController.java
+++ b/src/main/java/com/example/final_task/controller/SwimmersController.java
@@ -60,7 +60,7 @@ public class SwimmersController {
     @DeleteMapping("/swimmers/{id}")
     public ResponseEntity<String> delete(@PathVariable("id") int id) {
         swimmersService.delete(id);
-        return ResponseEntity.ok("data succesfull deleted!!");
+        return ResponseEntity.ok("data successfully deleted!!");
     }
 }
 

--- a/src/main/java/com/example/final_task/controller/SwimmersController.java
+++ b/src/main/java/com/example/final_task/controller/SwimmersController.java
@@ -5,10 +5,9 @@ import com.example.final_task.form.CreateSwimmer;
 import com.example.final_task.form.UpdateSwimmer;
 import com.example.final_task.mapper.SwimmersMapper;
 import com.example.final_task.service.SwimmersService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -56,6 +55,12 @@ public class SwimmersController {
     public ResponseEntity<String> update(@PathVariable("id") int id, @RequestBody @Validated UpdateSwimmer updateSwimmer) {
         swimmersService.update(id, updateSwimmer.getName(), updateSwimmer.getStroke());
         return ResponseEntity.ok("date successfully updated!");
+    }
+
+    @DeleteMapping("/swimmers/{id}")
+    public ResponseEntity<String> delete(@PathVariable("id") int id) {
+        swimmersService.delete(id);
+        return ResponseEntity.ok("data succesfull deleted!!");
     }
 }
 

--- a/src/main/java/com/example/final_task/mapper/SwimmersMapper.java
+++ b/src/main/java/com/example/final_task/mapper/SwimmersMapper.java
@@ -1,6 +1,7 @@
 package com.example.final_task.mapper;
 
 import com.example.final_task.entity.Swimmer;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -24,4 +25,7 @@ public interface SwimmersMapper {
 
     @Update("UPDATE swimmers SET name = #{name}, stroke= #{stroke} WHERE id = #{id}")
     void update(int id, String name, String stroke);
+
+    @Delete("DELETE FROM swimmers WHERE id = #{id}")
+    void delete(int id);
 }

--- a/src/main/java/com/example/final_task/service/SwimmersService.java
+++ b/src/main/java/com/example/final_task/service/SwimmersService.java
@@ -15,4 +15,6 @@ public interface SwimmersService {
 
     void update(int id, String name, String stroke);
 
+    void delete(int id);
+
 }

--- a/src/main/java/com/example/final_task/service/SwimmersServiceImpl.java
+++ b/src/main/java/com/example/final_task/service/SwimmersServiceImpl.java
@@ -47,4 +47,14 @@ public class SwimmersServiceImpl implements SwimmersService {
         );
     }
 
+    @Override
+    public void delete(int id) {
+        Optional<Swimmer> swimmer = swimmersMapper.findById(id);
+        swimmer.ifPresentOrElse(
+                s -> swimmersMapper.delete(id),
+                () -> {
+                    throw new ResourceNotFoundException("cannot find data!!");
+                }
+        );
+    }
 }


### PR DESCRIPTION
### 削除機能実装開始
削除機能を実装しました。実行結果は以下の通りです。
通常の削除を行うと設定した`data succesfull deleted‼`が返ってきます。データベースでも
でも削除されたのが確認できました。
```
$ curl -X DELETE http://localhost:8080/swimmers/1
```
```
data succesfull deleted‼
```
```
mysql> select * from swimmers;
+----+------------------+--------------+
| id | name             | stroke       |
+----+------------------+--------------+
|  2 | irie ryosuke     | backstroke   |
|  3 | tarakawa aya     | backstroke   |
|  4 | yanagawa taiju   | backstroke   |
|  5 | tanaka taikan    | free style   |
|  6 | tanaka taikan    | free style   |
|  7 | ikemoto nagisa   | free style   |
|  8 | nannba miyu      | free style   |
|  9 | suzuki rio       | free style   |
| 10 | hirai mizuki     | butterfly    |
| 11 | mizunuma naoki   | butterfly    |
| 12 | kawamoto takeshi | butterfly    |
| 13 | mura ryuya       | breastDtroke |
| 14 | taniguti taku    | breastDtroke |
| 15 | suzuki satomi    | breastDtroke |
+----+------------------+--------------+
14 rows in set (0.03 sec)
```

まだ生成されていないIdをしていすると、設定したメッセージ`cannot find data!!`と共にエラーメッセージを返すことが出来ます。
```
$ curl -X DELETE http://localhost:8080/swimmers/100
```
```
{"timestamp":"2023-09-29T12:58:36.931302500+09:00[GMT+09:00]","message":"cannot find data!!","status":"404","path":"/swimmers/100","error":"Not Found"}
```