### PR TITLE
Unit test find by id error

### DIFF
--- a/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
+++ b/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -29,12 +30,19 @@ class SwimmersServiceImplTest {
                 new Swimmer("meboso kodai", "breaststroke"),
                 new Swimmer("ikee rikkako", "butterfly"),
                 new Swimmer("irie ryosuke", "backstroke")
-                );
+        );
         doReturn(swimmerList).when(swimmersMapper).findAll();
         //テスト対象メソッドの呼び出し
         List<Swimmer> actual = swimmersServicelmpl.findAll();
         assertThat(actual).isEqualTo(swimmerList);
         verify(swimmersMapper, times(1)).findAll();
     }
+
+    @Test
+    public void 存在しないIDを指定したときにResourceNotFoundExceptionが発生すること() {
+        doReturn(Optional.empty()).when(swimmersMapper).findById(100);
+
+    }
+
 
 }

--- a/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
+++ b/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.example.final_task.service;
 
 import com.example.final_task.entity.Swimmer;
+import com.example.final_task.exception.ResourceNotFoundException;
 import com.example.final_task.mapper.SwimmersMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,6 +44,9 @@ class SwimmersServiceImplTest {
     public void 存在しないIDを指定したときにResourceNotFoundExceptionが発生すること() {
         doReturn(Optional.empty()).when(swimmersMapper).findById(100);
 
+        assertThatThrownBy(() -> swimmersServicelmpl.findById(100))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("cannot find data!!");
     }
 
 


### PR DESCRIPTION
### ID検索例外処理テスト
例外処理のテストコードを作成しました。
実行結果は以下の通りです。
```

> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
BUILD SUCCESSFUL in 11s
4 actionable tasks: 1 executed, 3 up-to-date
18:30:59: Execution finished ':test --tests "com.example.final_task.service.SwimmersServiceImplTest.存在しないIDを指定したときにResourceNotFoundExceptionが発生すること"'.

```
ご確認よろしくお願いいたします。