### PR TITLE
Test update

### DIFF
--- a/src/main/java/com/example/final_task/form/UpdateSwimmerForm.java
+++ b/src/main/java/com/example/final_task/form/UpdateSwimmerForm.java
@@ -7,12 +7,18 @@ import lombok.Setter;
 @Getter
 @Setter
 public class UpdateSwimmerForm {
+    private int id;
     private String name;
     private String stroke;
 
-    @AssertTrue(message = "name or stroke cannot null!")
+    public UpdateSwimmerForm(int id, String name, String stroke) {
+        this.id = id;
+        this.name = name;
+        this.stroke = stroke;
+    }
+
+    @AssertTrue(message = "Name or stroke cannot null!")
     public boolean isNameOrStrokeNotBlank() {
-        // nameかstrokeがnullまたは空文字または半角スペースのときにfalseを返す
         if (name == null || stroke == null) {
             return false;
         } else return !name.isBlank() && !stroke.isBlank();

--- a/src/main/java/com/example/final_task/form/UpdateSwimmerForm.java
+++ b/src/main/java/com/example/final_task/form/UpdateSwimmerForm.java
@@ -11,8 +11,7 @@ public class UpdateSwimmerForm {
     private String name;
     private String stroke;
 
-    public UpdateSwimmerForm(int id, String name, String stroke) {
-        this.id = id;
+    public UpdateSwimmerForm(String name, String stroke) {
         this.name = name;
         this.stroke = stroke;
     }

--- a/src/test/java/com/example/final_task/form/UpdateSwimmerFormTest.java
+++ b/src/test/java/com/example/final_task/form/UpdateSwimmerFormTest.java
@@ -1,0 +1,100 @@
+package com.example.final_task.form;
+
+import com.example.final_task.mapper.SwimmersMapper;
+import com.example.final_task.service.SwimmersServiceImpl;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.util.Set;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class UpdateSwimmerFormTest {
+    public static Validator validator;
+
+    SwimmersServiceImpl swimmersServiceImpl;
+
+    SwimmersMapper swimmersMapper;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void UpdateSwimmerFormのidとnameとstrokeも正常値である場合errorを返さないこと() {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "r4EpE1t", "101PK1a");
+        Set<ConstraintViolation<UpdateSwimmerForm>> result =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat((result.size())).isEqualTo(0);
+    }
+
+    @Test
+    public void UpdateSwimmerFormのnameがnullのときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, null, "cAmfag");
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+
+    @Test
+    public void UpdateSwimmerFormのnameが空文字のときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "", "9P2");
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+
+    @Test
+    public void UpdateSwimmerFormのstrokeがnullのときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "5ZeeRR", null);
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+
+    @Test
+    public void UpdateSwimmerFormのstrokeが空文字のときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "lt6", "");
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+}

--- a/src/test/java/com/example/final_task/form/UpdateSwimmerFormTest.java
+++ b/src/test/java/com/example/final_task/form/UpdateSwimmerFormTest.java
@@ -1,7 +1,5 @@
 package com.example.final_task.form;
 
-import com.example.final_task.mapper.SwimmersMapper;
-import com.example.final_task.service.SwimmersServiceImpl;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -16,10 +14,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 public class UpdateSwimmerFormTest {
     public static Validator validator;
-
-    SwimmersServiceImpl swimmersServiceImpl;
-
-    SwimmersMapper swimmersMapper;
 
     @BeforeAll
     public static void setUpValidator() {
@@ -86,6 +80,36 @@ public class UpdateSwimmerFormTest {
     @Test
     public void UpdateSwimmerFormのstrokeが空文字のときにerrorを返すこと() throws ParseException {
         UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "lt6", "");
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+
+    @Test
+    public void UpdateSwimmerFormのnameとstrokeがnullのときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, null, null);
+        Set<ConstraintViolation<UpdateSwimmerForm>> violations =
+                Validation
+                        .buildDefaultValidatorFactory()
+                        .getValidator()
+                        .validate(updateSwimmerForm);
+        assertThat(violations.size()).isEqualTo(1);
+        violations.forEach(action -> {
+            assertThat(action.getPropertyPath().toString()).isEqualTo("nameOrStrokeNotBlank");
+            assertThat(action.getMessage()).isEqualTo("Name or stroke cannot null!");
+        });
+    }
+
+    @Test
+    public void UpdateSwimmerFormのnameとstrokeが空文字のときにerrorを返すこと() throws ParseException {
+        UpdateSwimmerForm updateSwimmerForm = new UpdateSwimmerForm(1, "", "");
         Set<ConstraintViolation<UpdateSwimmerForm>> violations =
                 Validation
                         .buildDefaultValidatorFactory()

--- a/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
+++ b/src/test/java/com/example/final_task/service/SwimmersServiceImplTest.java
@@ -57,4 +57,13 @@ public class SwimmersServiceImplTest {
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("cannot find data!!");
     }
+
+    @Test
+    public void 存在しないIDのデータを更新たときにResourceNotFoundExceptionが発生すること() {
+        doReturn(Optional.empty()).when(swimmersMapper).findById(100);
+
+        assertThatThrownBy(() -> swimmersServiceImpl.update(100, "F2r", "03501jSm"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("cannot find data!!");
+    }
 }


### PR DESCRIPTION
### 更新処理テストコード作成
更新処理テストコードを作成しました。
UpdateSwimmerFormTestというクラスで、通常の更新処理が成功することとnameとstrokeがnullであったり空文字であったりする場合にerrorメッセージを返すことをテストしました。
[こちら](https://www.baeldung.com/java-validation-list-annotations)を参考にして作成しました。
ServiceImplTestクラスでは、存在しないIDを持つデータの更新を行おうとしたらerrorメッセージが返されるテストコードを作成しました。
ご確認よろしくお願いいたします。