### PR TITLE
Replace:Delete sql annotetion befere each test methods and place it b…

### DIFF
--- a/src/test/java/com/example/final_task/mapper/SwimmersMapperTest.java
+++ b/src/test/java/com/example/final_task/mapper/SwimmersMapperTest.java
@@ -15,15 +15,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @MybatisTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql(
+        scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
 class SwimmersMapperTest {
 
     @Autowired
     SwimmersMapper swimmersMapper;
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 全ての水泳選手が取得できること() {
@@ -37,10 +37,6 @@ class SwimmersMapperTest {
                 );
     }
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 指定した水泳選手が取得できること() {
@@ -48,10 +44,6 @@ class SwimmersMapperTest {
         assertThat(swimmer).isEqualTo((Optional.of(new Swimmer(1, "Michael Phelps", "Butterfly"))));
     }
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 指定したidが存在しない場合に返ってくるデータが空であること() {
@@ -60,10 +52,6 @@ class SwimmersMapperTest {
         assertThat(swimmer).isEmpty();
     }
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 新しい水泳選手が登録できること() {
@@ -75,10 +63,6 @@ class SwimmersMapperTest {
         assertThat(retrievedSwimmer.get().getStroke()).isEqualTo(swimmer.getStroke());
     }
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 更新した水泳選手の情報が反映されること() {
@@ -89,10 +73,6 @@ class SwimmersMapperTest {
         assertThat(updatedSwimmer).isEqualTo(Optional.of(new Swimmer(1, "Sarah Sjostrom", "IM")));
     }
 
-    @Sql(
-            scripts = {"classpath:/delete-swimmers.sql", "classpath:/insert-swimmers.sql"},
-            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
-    )
     @Test
     @Transactional
     void 水泳選手が削除できること() {


### PR DESCRIPTION
### ＠sqlをクラスの外側で宣言
今回それぞれのテストメソッドの前に宣言されていた＠sqlを、classの外側で宣言してみました。
なぜこのような試みをしたかというと、同じ宣言が繰り返されていることでコードが冗長になっており、省略できないかと思ったからです。
AIに聞いたところ、classの外側での宣言でも同じ効果が得られると言われたし、テストも成功したのでいいのかなと思いました。

先生方の見解はいかがでしょうか？

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- テスト: `SwimmersMapperTest`クラスのテストメソッドから`@Sql`アノテーションが移動されました。以前は、各テストメソッドの前にSQLスクリプトを実行するために`@Sql`アノテーションが使用されていました。現在では、`@Sql`アノテーションはクラスレベルに移動し、各テストメソッドの前に実行されます。この変更により、SQLスクリプトは各テストメソッドの前に一貫して実行されることが保証されます。テストメソッド自体は変更されていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->